### PR TITLE
Don't modify AH in FCB functions.

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -2550,6 +2550,7 @@ void execute(void)
 }
 
 // Set CPU registers from outside
+void cpuSetAL(unsigned v) { wregs[AX] = (wregs[AX] & 0xFF00) | (v & 0xFF); }
 void cpuSetAX(unsigned v) { wregs[AX] = v; }
 void cpuSetCX(unsigned v) { wregs[CX] = v; }
 void cpuSetDX(unsigned v) { wregs[DX] = v; }

--- a/src/emu.h
+++ b/src/emu.h
@@ -32,6 +32,7 @@ void emulator_update(void);
 void cpuTriggerIRQ(int num);
 
 // Register reading/writing
+void cpuSetAL(unsigned v);
 void cpuSetAX(unsigned v);
 void cpuSetCX(unsigned v);
 void cpuSetDX(unsigned v);


### PR DESCRIPTION
Also, simplify code by creating a function to set AL register.

This closes #8 and closes #9.